### PR TITLE
Add responsive.data() method to get cell data

### DIFF
--- a/js/dataTables.responsive.js
+++ b/js/dataTables.responsive.js
@@ -744,6 +744,11 @@ Api.register( 'responsive.index()', function ( li ) {
 	};
 } );
 
+Api.register( 'responsive.data()', function ( li ) {
+	li = $(li);
+
+	return li.find('span.dtr-data').text();
+} );
 
 /**
  * Version information


### PR DESCRIPTION
Now it is possible to get the cell data typing `table.responsive.data( li_object )`