### PR TITLE
Making collapsable content accessible via tabindex and keyboard

### DIFF
--- a/js/dataTables.responsive.js
+++ b/js/dataTables.responsive.js
@@ -433,6 +433,9 @@ Responsive.prototype = {
 		if ( details.type === 'inline' ) {
 			details.target = 'td:first-child';
 		}
+		
+		//Allowing each row to get tab focus
+		$( 'tbody > ' + details.target ).attr( 'tabindex',0 );
 
 		// type.target can be a string jQuery selector or a column index
 		var target   = details.target;
@@ -476,6 +479,13 @@ Responsive.prototype = {
 				$( row.node() ).addClass( 'parent' );
 			}
 		} );
+		
+		//Capturing generic event of enter key when a row is highlighted.
+		$( 'tr' ).keypress(function(e) {
+			if( e.which == 13 ) {//Enter key pressed
+				$(e.currentTarget).click();
+			}
+		});
 	},
 
 


### PR DESCRIPTION
Adding a tabindex to each row, and then adding an event handler to capture the enter key on each row, and then generate a click event to make the responsive datatable accessible.  This is in response to #37 and is a fix I implemented in my own code to make it accessible for users.