### PR TITLE
Some styles should not be applied when empty table

### DIFF
--- a/css/responsive.dataTables.scss
+++ b/css/responsive.dataTables.scss
@@ -39,8 +39,8 @@ $close-button-background: #d33333 !default;
 table.dataTable {
 	// Styling for the `inline` type
 	&.dtr-inline.collapsed > tbody {
-		> tr > td:first-child,
-		> tr > th:first-child {
+		> tr > td:first-child:not(.dataTables_empty),
+		> tr > th:first-child:not(.dataTables_empty) {
 			position: relative;
 			padding-left: 30px;
 			cursor: pointer;
@@ -52,10 +52,6 @@ table.dataTable {
 				width: 16px;
 				@include control;
 				@include control-open;
-			}
-
-			&.dataTables_empty:before {
-				display: none;
 			}
 		}
 
@@ -73,8 +69,8 @@ table.dataTable {
 
 	// DataTables' `compact` styling
 	&.dtr-inline.collapsed.compact > tbody {
-		> tr > td:first-child,
-		> tr > th:first-child {
+		> tr > td:first-child:not(.dataTables_empty),
+		> tr > th:first-child:not(.dataTables_empty) {
 			padding-left: 27px;
 
 			&:before {


### PR DESCRIPTION
In the generated css, here are the styles that leave room for the row expansion button:

```css
table.dataTable.dtr-inline.collapsed > tbody > tr > td:first-child,
table.dataTable.dtr-inline.collapsed > tbody > tr > th:first-child {
  position: relative;
  padding-left: 30px;
  cursor: pointer;
}
```

These selectors incorrectly match the empty data element (ex. when empty data returned from server):
```html
<tbody>
   <tr class="odd">
      <td valign="top" colspan="5" class="dataTables_empty">No data available in table</td>
   </tr>
</tbody>
```
The three styles should not be applied (`cursor` should not be pointer, `padding-left` messes with the `text-align:center` of the `.dataTables_empty`).

Altering the selectors like this should work:
```css
table.dataTable.dtr-inline.collapsed > tbody > tr > td:first-child:not(.dataTables_empty),
table.dataTable.dtr-inline.collapsed > tbody > tr > th:first-child:not(.dataTables_empty) {
  position: relative;
  padding-left: 30px;
  cursor: pointer;
}
```
I also fixed the styling for when the `compact` class is applied.