### PR TITLE
Added new event to fire when columns are shown or collapsed

### DIFF
--- a/js/dataTables.responsive.js
+++ b/js/dataTables.responsive.js
@@ -713,6 +713,8 @@ $.extend( Responsive.prototype, {
 
 		if ( changed ) {
 			this._redrawChildren();
+			// trigger the resize event when a column has collapsed or been shown in responsive
+			$(dt.table().node()).trigger( 'responsive-resize.dt', [dt, this.s.current] );
 		}
 	},
 


### PR DESCRIPTION
Event: responsive-resize.dt
	Parameters: 
		dataTable - DataTable instance
		 columnsVisibleArray - boolean array specifying if the columns are shown(true) or collapsed(false)