### PR TITLE
Fixed issue: responsive.details.type = 'column' prevents text selection.

### DIFF
--- a/js/dataTables.responsive.js
+++ b/js/dataTables.responsive.js
@@ -567,11 +567,7 @@ $.extend( Responsive.prototype, {
 
 		// Click handler to show / hide the details rows when they are available
 		$( dt.table().body() )
-			.on( 'mousedown.dtr', selector, function (e) {
-				// For mouse users, prevent the focus ring from showing
-				e.preventDefault();
-			} )
-			.on( 'click.dtr', selector, function () {
+			.on( 'click.dtr mousedown.dtr', selector, function () {
 				// If the table is not collapsed (i.e. there is no hidden columns)
 				// then take no action
 				if ( ! $(dt.table().node()).hasClass('collapsed' ) ) {
@@ -598,10 +594,16 @@ $.extend( Responsive.prototype, {
 				// $().closest() includes itself in its check
 				var row = dt.row( $(this).closest('tr') );
 
-				// The renderer is given as a function so the caller can execute it
-				// only when they need (i.e. if hiding there is no point is running
-				// the renderer)
-				that._detailsDisplay( row, false );
+				// Check event type to do an action
+				if(e.type === 'click'){
+					// The renderer is given as a function so the caller can execute it
+					// only when they need (i.e. if hiding there is no point is running
+					// the renderer)
+					that._detailsDisplay( row, false );
+				}else if(e.type === 'mousedown'){
+					// For mouse users, prevent the focus ring from showing
+					e.preventDefault();
+				}
 			} );
 	},
 

--- a/js/dataTables.responsive.js
+++ b/js/dataTables.responsive.js
@@ -595,12 +595,13 @@ $.extend( Responsive.prototype, {
 				var row = dt.row( $(this).closest('tr') );
 
 				// Check event type to do an action
-				if(e.type === 'click'){
+				if ( e.type === 'click' ) {
 					// The renderer is given as a function so the caller can execute it
 					// only when they need (i.e. if hiding there is no point is running
 					// the renderer)
 					that._detailsDisplay( row, false );
-				}else if(e.type === 'mousedown'){
+				}
+				else if ( e.type === 'mousedown' ) {
 					// For mouse users, prevent the focus ring from showing
 					e.preventDefault();
 				}


### PR DESCRIPTION
There was set an 'onmousedown' event to prevent the focus ring from showing.
The problem was that it was applied to all columns and that was preventing the text selection inside normal columns.
Now this event is only applied to the responsive column.