### PR TITLE
_resizeAuto footer size bug

### DIFF
--- a/js/dataTables.responsive.js
+++ b/js/dataTables.responsive.js
@@ -813,7 +813,7 @@ $.extend( Responsive.prototype, {
 		if ( footer ) {
 			var clonedFooter = $( footer.cloneNode( false ) ).appendTo( clonedTable );
 			var footerCells = dt.columns()
-				.header()
+				.footer()
 				.filter( function (idx) {
 					return dt.column(idx).visible();
 				} )


### PR DESCRIPTION
Small bugfix where footer was not considered into the size of the table causing overflow.
This was caused by the footer being assumed to be the same as header. 