### PR TITLE
Fix: Radio checked state lost when _resizeAuto run

### DIFF
--- a/js/dataTables.responsive.js
+++ b/js/dataTables.responsive.js
@@ -836,7 +836,12 @@ $.extend( Responsive.prototype, {
 		if ( this.c.details.type === 'inline' ) {
 			$(clonedTable).addClass( 'dtr-inline collapsed' );
 		}
-
+		
+		// It is unsafe to insert elements with the same name into the DOM
+		// multiple times. For example, cloning and inserting a checked radio
+		// clears the chcecked state of the original radio.
+		$( clonedTable ).find( '[name]' ).removeAttr( 'name' );
+		
 		var inserted = $('<div/>')
 			.css( {
 				width: 1,


### PR DESCRIPTION
- Name attributes must be removed from elements before the sizing
  clone is injected into the page to avoid adverse affects with
  selected radio inputs

When a checked radio is inserted into the dom with the same name as another radio that is checked, the original radio is unselected... effectively loosing the selection.

This patch removes name attributes before the cloned table is inserted into the dom for sizing..