### PR TITLE
FIX: nested tables break responsivnes of other columns

### DIFF
--- a/js/dataTables.responsive.js
+++ b/js/dataTables.responsive.js
@@ -166,7 +166,7 @@ $.extend( Responsive.prototype, {
 		// new data is added
 		dtPrivateSettings.oApi._fnCallbackReg( dtPrivateSettings, 'aoRowCreatedCallback', function (tr, data, idx) {
 			if ( $.inArray( false, that.s.current ) !== -1 ) {
-				$('td, th', tr).each( function ( i ) {
+				$('>td, >th', tr).each( function ( i ) {
 					var idx = dt.column.index( 'toData', i );
 
 					if ( that.s.current[idx] === false ) {


### PR DESCRIPTION
When there is a nested table in a cell and it's loaded using ajax the
number of all found cells in a row is higher than number of columns in a
table. That breaks hiding cells at the end of a row.
I'm taking only immediate children or TR not all