### PR TITLE
fix: Custom complex footer overflow 

### DIFF
--- a/js/dataTables.responsive.js
+++ b/js/dataTables.responsive.js
@@ -811,7 +811,7 @@ $.extend( Responsive.prototype, {
 		// Footer
 		var footer = dt.table().footer();
 		if ( footer ) {
-			var clonedFooter = $( footer.cloneNode( false ) ).appendTo( clonedTable );
+			var clonedFooter = $( footer.cloneNode( true ) ).appendTo( clonedTable );
 			var footerCells = dt.columns()
 				.footer()
 				.filter( function (idx) {


### PR DESCRIPTION
Hello,
My instance of DatatTables used custom footer which were also formatted using, this caused the table to overflow at times.
Some debugging tracked the error to the calculation of the footer size, seems the cloned footer did not contain its child elements. This change fixed the issue for me, but possible the same error still subsides in the header. 

If you want to use it I'm happy if it is released under the MIT license.