### PR TITLE
Fix: Do not inherit `ul.dtr-details li` styles

### DIFF
--- a/css/responsive.dataTables.scss
+++ b/css/responsive.dataTables.scss
@@ -146,7 +146,7 @@ table.dataTable {
 			margin: 0;
 			padding: 0;
 
-			li {
+			> li {
 				border-bottom: 1px solid #efefef;
 				padding: 0.5em 0;
 


### PR DESCRIPTION
fix using `ul.dtr-details` under `li` bootstrap components like `ul.dropdown-menu > li` inherits `ul.dtr-details li` issue.