### PR TITLE
Fix: Duplicate `click` event with `Select` extension

### DIFF
--- a/js/dataTables.responsive.js
+++ b/js/dataTables.responsive.js
@@ -639,6 +639,7 @@ $.extend( Responsive.prototype, {
 					// The renderer is given as a function so the caller can execute it
 					// only when they need (i.e. if hiding there is no point is running
 					// the renderer)
+					e.stopPropagation();
 					that._detailsDisplay( row, false );
 				}
 				else if ( e.type === 'mousedown' ) {


### PR DESCRIPTION
`Responsive` with `Select` (event selector: td:first-child),
show/hide button click event duplicated each event.

ex) When clicked show/hide button to just show collapsed column, fired select/unselect event too. 


```javascript
var options = {
  select: {
    style: 'multi',
    selector: 'td:first-child'
  }
}
```
just added `e.stopPropagation`.
