### PR TITLE
Fix: prevent interference with Select extension

### DIFF
--- a/js/dataTables.responsive.js
+++ b/js/dataTables.responsive.js
@@ -782,11 +782,17 @@ $.extend(Responsive.prototype, {
 		var selector = typeof target === 'string' ? target : 'td, th';
 
 		if (target !== undefined || target !== null) {
+			var dtSelectSelector = (dt.select && dt.select.selector());
 			// Click handler to show / hide the details rows when they are available
 			$(dt.table().body()).on(
 				'click.dtr mousedown.dtr mouseup.dtr',
 				selector,
 				function (e) {
+          // If the Select extension is in use and the user clicked something
+          // matching Select's selector, ignore the event
+          if (dtSelectSelector && $(e.target).is(dtSelectSelector))
+						return;
+
 					// If the table is not collapsed (i.e. there is no hidden columns)
 					// then take no action
 					if (!$(dt.table().node()).hasClass('collapsed')) {


### PR DESCRIPTION
I'm not 100% of any potential negative side effects this could have, but I got tired of having Responsive (in inline control mode) toggling child rows every time I'd go to click on Select's checkbox for a row. This prevents that.