### PR TITLE
"Modal": Only print the colon if the title is not empty

### DIFF
--- a/js/dataTables.responsive.js
+++ b/js/dataTables.responsive.js
@@ -1616,8 +1616,10 @@ Responsive.renderer = {
 					col.columnIndex +
 					'">' +
 					'<td>' +
-					col.title +
-					':' +
+					( '' !== col.title
+						? col.title + ':'
+						: ''
+					) +
 					'</td> ' +
 					'<td>' +
 					col.data +


### PR DESCRIPTION
This prevents cells with just a `:` in them, if the column title is empty, as in this screenshot:

<img width="561" alt="modal-colon" src="https://github.com/user-attachments/assets/3bc52d06-9b2d-4df3-aba5-c0b2839a4cf8" />
